### PR TITLE
Add Talos single node initial manifests

### DIFF
--- a/gitops/apps/base/api-gateway.yaml
+++ b/gitops/apps/base/api-gateway.yaml
@@ -1,1 +1,20 @@
-# API gateway Deployment/Service
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: api-gateway
+  namespace: home
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: api-gateway
+  template:
+    metadata:
+      labels:
+        app: api-gateway
+    spec:
+      containers:
+        - name: api-gateway
+          image: nginx:alpine
+          ports:
+            - containerPort: 80

--- a/gitops/apps/base/code-server.yaml
+++ b/gitops/apps/base/code-server.yaml
@@ -1,1 +1,21 @@
-# Code-server Deployment and Service
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: code-server
+  namespace: home
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: code-server
+  template:
+    metadata:
+      labels:
+        app: code-server
+    spec:
+      containers:
+        - name: code-server
+          image: coder/code-server:latest
+          args: ["--bind-addr", "0.0.0.0:8080"]
+          ports:
+            - containerPort: 8080

--- a/gitops/apps/base/home-assistant.yaml
+++ b/gitops/apps/base/home-assistant.yaml
@@ -1,1 +1,26 @@
-# Home Assistant Deployment (common settings, no nodeSelectors yet)
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: home-assistant
+  namespace: home
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: home-assistant
+  template:
+    metadata:
+      labels:
+        app: home-assistant
+    spec:
+      containers:
+        - name: home-assistant
+          image: ghcr.io/home-assistant/home-assistant:stable
+          ports:
+            - containerPort: 8123
+          volumeMounts:
+            - mountPath: /config
+              name: config
+      volumes:
+        - name: config
+          emptyDir: {}

--- a/gitops/apps/base/mosquitto.yaml
+++ b/gitops/apps/base/mosquitto.yaml
@@ -1,1 +1,20 @@
-# MQTT broker Deployment/Service
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: mosquitto
+  namespace: home
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: mosquitto
+  template:
+    metadata:
+      labels:
+        app: mosquitto
+    spec:
+      containers:
+        - name: mosquitto
+          image: eclipse-mosquitto:2
+          ports:
+            - containerPort: 1883

--- a/gitops/apps/base/node-red.yaml
+++ b/gitops/apps/base/node-red.yaml
@@ -1,1 +1,20 @@
-# Node-RED Deployment
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: node-red
+  namespace: home
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: node-red
+  template:
+    metadata:
+      labels:
+        app: node-red
+    spec:
+      containers:
+        - name: node-red
+          image: nodered/node-red:latest
+          ports:
+            - containerPort: 1880

--- a/gitops/apps/base/zigbee2mqtt.yaml
+++ b/gitops/apps/base/zigbee2mqtt.yaml
@@ -1,1 +1,27 @@
-# Zigbee2MQTT Deployment (no specific USB path here, to be patched per env)
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: zigbee2mqtt
+  namespace: home
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: zigbee2mqtt
+  template:
+    metadata:
+      labels:
+        app: zigbee2mqtt
+    spec:
+      containers:
+        - name: zigbee2mqtt
+          image: koenkk/zigbee2mqtt:latest
+          env:
+            - name: MQTT_SERVER
+              value: "mqtt://mosquitto.home.svc.cluster.local:1883"
+          volumeMounts:
+            - mountPath: /app/data
+              name: data
+      volumes:
+        - name: data
+          emptyDir: {}

--- a/gitops/apps/overlays/home-single/hass-hostnetwork-patch.yaml
+++ b/gitops/apps/overlays/home-single/hass-hostnetwork-patch.yaml
@@ -1,1 +1,8 @@
-# Patch Home Assistant to use hostNetwork: true (maybe only on single node)
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: home-assistant
+spec:
+  template:
+    spec:
+      hostNetwork: true

--- a/gitops/apps/overlays/home-single/kustomization.yaml
+++ b/gitops/apps/overlays/home-single/kustomization.yaml
@@ -1,0 +1,13 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ../../base/home-assistant.yaml
+  - ../../base/node-red.yaml
+  - ../../base/code-server.yaml
+  - ../../base/mosquitto.yaml
+  - ../../base/zigbee2mqtt.yaml
+  - ../../base/api-gateway.yaml
+patchesStrategicMerge:
+  - hass-hostnetwork-patch.yaml
+  - zigbee2mqtt-patch.yaml
+  - replicas-patch.yaml

--- a/gitops/apps/overlays/home-single/replicas-patch.yaml
+++ b/gitops/apps/overlays/home-single/replicas-patch.yaml
@@ -1,1 +1,41 @@
-# Scale down certain deployments if single node (e.g., 1 replica instead of 2)
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: home-assistant
+spec:
+  replicas: 1
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: node-red
+spec:
+  replicas: 1
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: code-server
+spec:
+  replicas: 1
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: mosquitto
+spec:
+  replicas: 1
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: zigbee2mqtt
+spec:
+  replicas: 1
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: api-gateway
+spec:
+  replicas: 1

--- a/gitops/apps/overlays/home-single/zigbee2mqtt-patch.yaml
+++ b/gitops/apps/overlays/home-single/zigbee2mqtt-patch.yaml
@@ -1,1 +1,18 @@
-# Patch to add nodeSelector for the node with USB, and device mount (ttyUSB0)
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: zigbee2mqtt
+spec:
+  template:
+    spec:
+      containers:
+        - name: zigbee2mqtt
+          volumeMounts:
+            - mountPath: /dev/ttyUSB0
+              name: usb
+      volumes:
+        - name: usb
+          hostPath:
+            path: /dev/ttyUSB0
+      nodeSelector:
+        kubernetes.io/hostname: talos-node

--- a/gitops/clusters/home-single/kustomization.yaml
+++ b/gitops/clusters/home-single/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ../../infrastructure/overlays/home-single
+  - ../../apps/overlays/home-single

--- a/gitops/infrastructure/base/cloudflare-tunnel.yaml
+++ b/gitops/infrastructure/base/cloudflare-tunnel.yaml
@@ -1,1 +1,25 @@
-# Deployment for cloudflared (no secrets here, token via Secret)
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: cloudflared
+  namespace: networking
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: cloudflared
+  template:
+    metadata:
+      labels:
+        app: cloudflared
+    spec:
+      containers:
+        - name: cloudflared
+          image: cloudflare/cloudflared:latest
+          args: ["tunnel", "--no-autoupdate", "run"]
+          env:
+            - name: TUNNEL_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: cloudflared-token
+                  key: token

--- a/gitops/infrastructure/base/coredns-configmap.yaml
+++ b/gitops/infrastructure/base/coredns-configmap.yaml
@@ -1,1 +1,20 @@
-# Custom CoreDNS config if needed (e.g., stub domains)
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: coredns
+  namespace: kube-system
+data:
+  Corefile: |
+    .:53 {
+        errors
+        health
+        kubernetes cluster.local in-addr.arpa ip6.arpa {
+           pods insecure
+           fallthrough in-addr.arpa ip6.arpa
+        }
+        forward . /etc/resolv.conf
+        cache 30
+        loop
+        reload
+        loadbalance
+    }

--- a/gitops/infrastructure/base/externaldns.yaml
+++ b/gitops/infrastructure/base/externaldns.yaml
@@ -1,1 +1,25 @@
-# ExternalDNS configured for Pi-hole or OPNsense
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: external-dns
+  namespace: networking
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: external-dns
+  template:
+    metadata:
+      labels:
+        app: external-dns
+    spec:
+      containers:
+        - name: external-dns
+          image: registry.k8s.io/external-dns/external-dns:v0.13.5
+          args:
+            - --source=service
+            - --source=ingress
+            - --provider=pihole
+            - --policy=sync
+            - --registry=txt
+            - --txt-owner-id=homernetes

--- a/gitops/infrastructure/base/ingress-nginx.yaml
+++ b/gitops/infrastructure/base/ingress-nginx.yaml
@@ -1,1 +1,35 @@
-# Ingress controller Deployment/Service (with no env-specific config)
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: ingress-nginx
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: controller
+  namespace: ingress-nginx
+spec:
+  selector:
+    matchLabels:
+      app: ingress-nginx
+  template:
+    metadata:
+      labels:
+        app: ingress-nginx
+    spec:
+      hostNetwork: true
+      containers:
+        - name: controller
+          image: registry.k8s.io/ingress-nginx/controller:v1.9.0
+          args:
+            - /nginx-ingress-controller
+          ports:
+            - containerPort: 80
+              hostPort: 80
+            - containerPort: 443
+              hostPort: 443
+          securityContext:
+            capabilities:
+              add:
+                - NET_BIND_SERVICE
+            allowPrivilegeEscalation: true

--- a/gitops/infrastructure/base/metallb.yaml
+++ b/gitops/infrastructure/base/metallb.yaml
@@ -1,1 +1,54 @@
-# MetalLB config (address pools might be set in overlay though)
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: metallb-system
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: controller
+  namespace: metallb-system
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      component: controller
+  template:
+    metadata:
+      labels:
+        component: controller
+    spec:
+      containers:
+        - name: controller
+          image: quay.io/metallb/controller:v0.14.5
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: speaker
+  namespace: metallb-system
+spec:
+  selector:
+    matchLabels:
+      component: speaker
+  template:
+    metadata:
+      labels:
+        component: speaker
+    spec:
+      containers:
+        - name: speaker
+          image: quay.io/metallb/speaker:v0.14.5
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: metallb-config
+  namespace: metallb-system
+data:
+  config: |
+    address-pools:
+    - name: default
+      protocol: layer2
+      addresses:
+      - 192.168.1.240-192.168.1.250

--- a/gitops/infrastructure/overlays/home-single/ingress-patch.yaml
+++ b/gitops/infrastructure/overlays/home-single/ingress-patch.yaml
@@ -1,1 +1,12 @@
-# Patch ingress DaemonSet to tolerate master (single node serving ingress)
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: controller
+  namespace: ingress-nginx
+spec:
+  template:
+    spec:
+      tolerations:
+        - key: node-role.kubernetes.io/control-plane
+          operator: Exists
+          effect: NoSchedule

--- a/gitops/infrastructure/overlays/home-single/kustomization.yaml
+++ b/gitops/infrastructure/overlays/home-single/kustomization.yaml
@@ -1,1 +1,11 @@
-# Kustomization that patches base manifests for single env
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ../../base/cloudflare-tunnel.yaml
+  - ../../base/coredns-configmap.yaml
+  - ../../base/externaldns.yaml
+  - ../../base/ingress-nginx.yaml
+  - ../../base/metallb.yaml
+patchesStrategicMerge:
+  - metallb-pool-patch.yaml
+  - ingress-patch.yaml

--- a/gitops/infrastructure/overlays/home-single/metallb-pool-patch.yaml
+++ b/gitops/infrastructure/overlays/home-single/metallb-pool-patch.yaml
@@ -1,1 +1,12 @@
-# Patch MetalLB config to use a single node IP range or address
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: metallb-config
+  namespace: metallb-system
+data:
+  config: |
+    address-pools:
+    - name: default
+      protocol: layer2
+      addresses:
+      - 192.168.1.240-192.168.1.250


### PR DESCRIPTION
## Summary
- populate empty Kubernetes YAML files for a Talos single-node setup
- create base manifests for apps and infrastructure
- add overlays for the `home-single` environment
- wire overlays together with a cluster kustomization

## Testing
- `npx tsc`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced deployment manifests for core home automation and infrastructure applications, including Home Assistant, Node-RED, code-server, Mosquitto, Zigbee2MQTT, API gateway, and supporting services.
  - Added configuration for ingress, DNS, MetalLB load balancer, and Cloudflare tunnel for network and external access.
  - Implemented overlays and patches for single-node environments, including host networking, volume mounts, node affinity, and replica settings.
  - Provided Kustomize configurations for modular and environment-specific deployments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->